### PR TITLE
Add tourisme non-classe micro‑BIC test

### DIFF
--- a/lmnp_tax_engine/core/engine.py
+++ b/lmnp_tax_engine/core/engine.py
@@ -26,17 +26,16 @@ def calculate(
     cfg = load_config(year)
 
     if regime == "micro_bic":
-        abat_pct = cfg["micro_bic"]["taux_abattement"][property.classification]
-        from decimal import Decimal
-        abat_pct_dec = Decimal(str(abat_pct))
-        taxable_base = gross_rent * (Decimal("1") - abat_pct_dec)
+        abat_rate = cfg["micro_bic"]["taux_abattement"][property.classification]
+        abat_pct = Decimal(str(abat_rate))
+        taxable_base = gross_rent * (Decimal("1") - abat_pct)
         return RegimeResult(
             year=year,
             regime=regime,
             taxable_income=taxable_base,
             income_tax=Decimal(0),           # placeholder for now
             social_contributions=Decimal(0),
-            explanation=f"Abattement {abat_pct_dec:.0%} appliqué",
+            explanation=f"Abattement {abat_pct:.0%} appliqué ({property.classification})",
         )
 
     raise NotImplementedError(regime)

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -20,3 +20,23 @@ def test_micro_bic_abattement_classique_2025():
         year=2025,
     )
     assert result.taxable_income == Decimal("10000")
+
+
+def test_micro_bic_abattement_tourisme_non_classe_2025():
+    """Gross rent 12 000 €, tourisme_non_classe → 30 % abattement ⇒ taxable 8 400 €."""
+    prop = Property(
+        id="T1",
+        address="1 chemin du Test, Paris",
+        acquisition_price=Decimal("150000"),
+        acquisition_date=date(2021, 1, 15),
+        classification="tourisme_non_classe",
+    )
+    result = calculate(
+        property=prop,
+        gross_rent=Decimal("12000"),
+        charges=Decimal("0"),
+        regime="micro_bic",
+        year=2025,
+    )
+    assert result.taxable_income == Decimal("8400")
+    assert result.explanation == "Abattement 30% appliqué (tourisme_non_classe)"


### PR DESCRIPTION
## Summary
- verify micro-BIC abattement for non-classified tourism properties
- compute abattement rate from config with Decimal
- include property classification in explanation string

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683dce648c908328a04af97c77e1f214

Closes #1 – implements the 30 % abatement for tourisme_non_classe rentals.
